### PR TITLE
Fix the output and error file

### DIFF
--- a/src/toBG/toBG.go
+++ b/src/toBG/toBG.go
@@ -33,17 +33,20 @@ func setOutErrFiles(outF, errF string) (stdOut, stdErr io.Writer, err error) {
 		stdErr = ioutil.Discard
 		return
 	}
-	if outF != "" && errF == "" {
+	if errF == "" {
 		errF = outF
-	} else if errF != "" && outF == "" {
-		outF = errF
 	}
-	stdOut, err = os.Create(outF)
-	if err != nil {
-		return nil, nil, err
+	if outF == "" {
+		stdOut = ioutil.Discard
+	} else {
+		if stdOut, err = os.Create(errF); err != nil {
+			return nil, nil, err
+		}
 	}
-	if outF != errF {
-		stdErr, err = os.Create(errF)
+	if errF != outF {
+		if stdErr, err = os.Create(errF); err != nil {
+			return nil, nil, err
+		}
 	} else {
 		stdErr = stdOut
 	}


### PR DESCRIPTION
If output file argument is not provided, Stdout from the executing
command will be discarded. But on the otherhand, if error file is
discarded, Stderr from the executing command will be attached to the
output file.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>